### PR TITLE
Change `right` to `write`

### DIFF
--- a/docs/beginner/tutorial1-window/README.md
+++ b/docs/beginner/tutorial1-window/README.md
@@ -89,7 +89,7 @@ These lines tell cargo that we want to allow our crate to build a native Rust st
 
 ## Web Assembly
 
-Web Assembly ie WASM, is a binary format supported by most modern browsers that allows lower level languages such as Rust to run on a web page. This allows us to right the bulk of our application in Rust and use a few lines of Javascript to get it running in a web browser.
+Web Assembly ie WASM, is a binary format supported by most modern browsers that allows lower level languages such as Rust to run on a web page. This allows us to write the bulk of our application in Rust and use a few lines of Javascript to get it running in a web browser.
 
 </div>
 


### PR DESCRIPTION
In the firs tutorial, in `Web Assembly` section looks like there is a typo, it should say `write` but instead it says `right`. Sounds the same but is not the same. ;-)